### PR TITLE
Add sub-agent orchestration, cloud model flag, and web tools

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,0 +1,125 @@
+/**
+ * Agent Registry
+ * Central configuration for all sub-agent types
+ */
+
+import type { AgentType, AgentConfig } from "./types.ts";
+import { EXPLORE_PROMPT } from "./prompts/explore.ts";
+import { RESEARCH_PROMPT } from "./prompts/research.ts";
+import { PLAN_PROMPT } from "./prompts/plan.ts";
+import { EXECUTE_PROMPT } from "./prompts/execute.ts";
+import { REFACTOR_PROMPT } from "./prompts/refactor.ts";
+import { ASSESS_PROMPT } from "./prompts/assess.ts";
+import { VERIFY_PROMPT } from "./prompts/verify.ts";
+import type { Tool } from "../llm/client.ts";
+
+// CRITICAL: Low iteration limits enforce decomposition
+// If a task needs more iterations, it should be split into multiple agents
+export const AGENT_CONFIGS: Record<AgentType, AgentConfig> = {
+  explore: {
+    type: "explore",
+    name: "Explorer",
+    description: "Fast, focused file discovery - ONE specific search",
+    systemPrompt: EXPLORE_PROMPT,
+    allowedTools: ["glob", "grep", "read_file"],
+    maxIterations: 3,
+  },
+  research: {
+    type: "research",
+    name: "Researcher",
+    description: "Single web search query with focused results",
+    systemPrompt: RESEARCH_PROMPT,
+    allowedTools: ["web_search", "web_fetch", "read_file"],
+    maxIterations: 4,
+  },
+  plan: {
+    type: "plan",
+    name: "Planner",
+    description: "Design plan for ONE component/feature",
+    systemPrompt: PLAN_PROMPT,
+    allowedTools: ["glob", "grep", "read_file"],
+    maxIterations: 5,
+  },
+  execute: {
+    type: "execute",
+    name: "Executor",
+    description: "Implement ONE file or small set of related changes",
+    systemPrompt: EXECUTE_PROMPT,
+    allowedTools: [
+      "glob",
+      "grep",
+      "read_file",
+      "write_file",
+      "edit_file",
+      "bash",
+    ],
+    maxIterations: 5,
+  },
+  refactor: {
+    type: "refactor",
+    name: "Refactorer",
+    description: "Address ONE specific code quality issue",
+    systemPrompt: REFACTOR_PROMPT,
+    allowedTools: ["glob", "grep", "read_file", "edit_file"],
+    maxIterations: 4,
+  },
+  assess: {
+    type: "assess",
+    name: "Assessor",
+    description: "Evaluate ONE specific decision or feature",
+    systemPrompt: ASSESS_PROMPT,
+    allowedTools: ["read_file", "glob"],
+    maxIterations: 3,
+  },
+  verify: {
+    type: "verify",
+    name: "Verifier",
+    description: "Run ONE test suite or validation check",
+    systemPrompt: VERIFY_PROMPT,
+    allowedTools: ["bash", "read_file", "glob"],
+    maxIterations: 4,
+  },
+};
+
+/**
+ * Get agent configuration by type
+ */
+export function getAgentConfig(type: AgentType): AgentConfig {
+  return AGENT_CONFIGS[type];
+}
+
+/**
+ * Filter tools to only those allowed for an agent type
+ */
+export function filterToolsForAgent(
+  allTools: Tool[],
+  agentType: AgentType
+): Tool[] {
+  const config = AGENT_CONFIGS[agentType];
+  return allTools.filter((tool) =>
+    config.allowedTools.includes(tool.function.name)
+  );
+}
+
+/**
+ * Get all available agent types
+ */
+export function getAgentTypes(): AgentType[] {
+  return Object.keys(AGENT_CONFIGS) as AgentType[];
+}
+
+/**
+ * Check if a string is a valid agent type
+ */
+export function isValidAgentType(type: string): type is AgentType {
+  return type in AGENT_CONFIGS;
+}
+
+/**
+ * Get agent description for tool documentation
+ */
+export function getAgentDescriptions(): string {
+  return Object.values(AGENT_CONFIGS)
+    .map((config) => `- ${config.type}: ${config.description}`)
+    .join("\n");
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -112,7 +112,7 @@ export function getAgentTypes(): AgentType[] {
  * Check if a string is a valid agent type
  */
 export function isValidAgentType(type: string): type is AgentType {
-  return type in AGENT_CONFIGS;
+  return Object.prototype.hasOwnProperty.call(AGENT_CONFIGS, type);
 }
 
 /**

--- a/src/agents/parallel.ts
+++ b/src/agents/parallel.ts
@@ -20,6 +20,12 @@ export interface ParallelAgentCallbacks {
   onAgentError: (taskId: string, error: Error) => void;
 }
 
+/** Result of spawning multiple agents */
+export interface SpawnAllResult {
+  successes: Map<string, AgentResult>;
+  failures: Map<string, Error>;
+}
+
 export class ParallelAgentExecutor {
   private activeTasks: Map<string, SubAgentTask> = new Map();
   private callbacks: ParallelAgentCallbacks;
@@ -29,14 +35,27 @@ export class ParallelAgentExecutor {
   }
 
   /**
+   * Generate a unique task ID that doesn't collide with active tasks
+   */
+  private generateUniqueTaskId(maxAttempts = 100): string {
+    for (let i = 0; i < maxAttempts; i++) {
+      const taskId = generateTaskId();
+      if (!this.activeTasks.has(taskId)) {
+        return taskId;
+      }
+    }
+    throw new Error("Failed to generate unique task ID after maximum attempts");
+  }
+
+  /**
    * Spawn multiple agents in parallel
-   * Returns when ALL agents complete
+   * Returns when ALL agents complete, with both successes and failures
    */
   async spawnAll(
     tasks: { agentType: AgentType; prompt: string }[]
-  ): Promise<Map<string, AgentResult>> {
+  ): Promise<SpawnAllResult> {
     const taskIds = tasks.map((t) => {
-      const taskId = generateTaskId();
+      const taskId = this.generateUniqueTaskId();
       const task: SubAgentTask = {
         id: taskId,
         agentType: t.agentType,
@@ -52,16 +71,27 @@ export class ParallelAgentExecutor {
     const promises = taskIds.map((id) => this.executeTask(id));
     const settledResults = await Promise.allSettled(promises);
 
-    // Aggregate results
-    const results = new Map<string, AgentResult>();
+    // Aggregate results, tracking both successes and failures
+    const successes = new Map<string, AgentResult>();
+    const failures = new Map<string, Error>();
+
     settledResults.forEach((settled, index) => {
       const taskId = taskIds[index];
-      if (taskId && settled.status === "fulfilled") {
-        results.set(taskId, settled.value);
+      if (taskId) {
+        if (settled.status === "fulfilled") {
+          successes.set(taskId, settled.value);
+        } else {
+          failures.set(
+            taskId,
+            settled.reason instanceof Error
+              ? settled.reason
+              : new Error(String(settled.reason))
+          );
+        }
       }
     });
 
-    return results;
+    return { successes, failures };
   }
 
   /**

--- a/src/agents/parallel.ts
+++ b/src/agents/parallel.ts
@@ -1,0 +1,172 @@
+/**
+ * Parallel Agent Executor
+ * Manages concurrent agent execution with multiplexed output
+ */
+
+import type {
+  AgentType,
+  AgentResult,
+  SubAgentTask,
+  SubAgentCallbacks,
+} from "./types.ts";
+import { generateTaskId } from "./types.ts";
+import { runSubAgent } from "./runner.ts";
+
+export interface ParallelAgentCallbacks {
+  onAgentStart: (taskId: string, agentType: AgentType) => void;
+  onAgentProgress: (taskId: string, message: string) => void;
+  onAgentToolCall: (taskId: string, tool: string, args: string) => void;
+  onAgentComplete: (taskId: string, result: AgentResult) => void;
+  onAgentError: (taskId: string, error: Error) => void;
+}
+
+export class ParallelAgentExecutor {
+  private activeTasks: Map<string, SubAgentTask> = new Map();
+  private callbacks: ParallelAgentCallbacks;
+
+  constructor(callbacks: ParallelAgentCallbacks) {
+    this.callbacks = callbacks;
+  }
+
+  /**
+   * Spawn multiple agents in parallel
+   * Returns when ALL agents complete
+   */
+  async spawnAll(
+    tasks: { agentType: AgentType; prompt: string }[]
+  ): Promise<Map<string, AgentResult>> {
+    const taskIds = tasks.map((t) => {
+      const taskId = generateTaskId();
+      const task: SubAgentTask = {
+        id: taskId,
+        agentType: t.agentType,
+        prompt: t.prompt,
+        status: "pending",
+        startedAt: Date.now(),
+      };
+      this.activeTasks.set(taskId, task);
+      return taskId;
+    });
+
+    // Run all concurrently
+    const promises = taskIds.map((id) => this.executeTask(id));
+    const settledResults = await Promise.allSettled(promises);
+
+    // Aggregate results
+    const results = new Map<string, AgentResult>();
+    settledResults.forEach((settled, index) => {
+      const taskId = taskIds[index];
+      if (taskId && settled.status === "fulfilled") {
+        results.set(taskId, settled.value);
+      }
+    });
+
+    return results;
+  }
+
+  /**
+   * Spawn a single agent (can run while others are active)
+   */
+  async spawn(agentType: AgentType, prompt: string): Promise<AgentResult> {
+    const taskId = generateTaskId();
+    const task: SubAgentTask = {
+      id: taskId,
+      agentType,
+      prompt,
+      status: "pending",
+      startedAt: Date.now(),
+    };
+    this.activeTasks.set(taskId, task);
+    return this.executeTask(taskId);
+  }
+
+  /**
+   * Check if any agents are currently running
+   */
+  isRunning(): boolean {
+    return Array.from(this.activeTasks.values()).some(
+      (t) => t.status === "running"
+    );
+  }
+
+  /**
+   * Get status of all active tasks
+   */
+  getStatus(): SubAgentTask[] {
+    return Array.from(this.activeTasks.values());
+  }
+
+  /**
+   * Get a specific task by ID
+   */
+  getTask(taskId: string): SubAgentTask | undefined {
+    return this.activeTasks.get(taskId);
+  }
+
+  /**
+   * Clear completed tasks from memory
+   */
+  clearCompleted(): void {
+    for (const [id, task] of this.activeTasks) {
+      if (task.status === "completed" || task.status === "failed") {
+        this.activeTasks.delete(id);
+      }
+    }
+  }
+
+  /**
+   * Execute a single task
+   */
+  private async executeTask(taskId: string): Promise<AgentResult> {
+    const task = this.activeTasks.get(taskId);
+    if (!task) {
+      throw new Error(`Task ${taskId} not found`);
+    }
+
+    task.status = "running";
+    this.callbacks.onAgentStart(taskId, task.agentType);
+
+    // Create callbacks that route to the parallel callbacks with taskId
+    const subCallbacks: SubAgentCallbacks = {
+      onProgress: (msg) => this.callbacks.onAgentProgress(taskId, msg),
+      onToolCall: (tool, args) =>
+        this.callbacks.onAgentToolCall(taskId, tool, args),
+    };
+
+    try {
+      const result = await runSubAgent(task, subCallbacks);
+
+      task.status = "completed";
+      task.result = result;
+      task.completedAt = Date.now();
+
+      this.callbacks.onAgentComplete(taskId, result);
+      return result;
+    } catch (error) {
+      task.status = "failed";
+      task.error = error instanceof Error ? error.message : String(error);
+      task.completedAt = Date.now();
+
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.callbacks.onAgentError(taskId, err);
+      throw err;
+    }
+  }
+}
+
+/**
+ * Create a simple executor with console logging (for testing)
+ */
+export function createSimpleExecutor(): ParallelAgentExecutor {
+  return new ParallelAgentExecutor({
+    onAgentStart: (taskId, type) =>
+      console.log(`[${taskId}] Starting ${type} agent...`),
+    onAgentProgress: (taskId, msg) => console.log(`[${taskId}] ${msg}`),
+    onAgentToolCall: (taskId, tool, args) =>
+      console.log(`[${taskId}] Tool: ${tool}(${args.slice(0, 50)}...)`),
+    onAgentComplete: (taskId, result) =>
+      console.log(`[${taskId}] Complete: ${result.summary}`),
+    onAgentError: (taskId, error) =>
+      console.error(`[${taskId}] Error: ${error.message}`),
+  });
+}

--- a/src/agents/prompts/assess.ts
+++ b/src/agents/prompts/assess.ts
@@ -1,0 +1,33 @@
+/**
+ * Assess Agent System Prompt
+ * Evaluate ONE specific decision or feature
+ */
+
+export const ASSESS_PROMPT = `You are a business assessment agent.
+
+## Your Mission
+Evaluate ONE specific decision, feature, or approach from a business perspective.
+
+## Tools Available
+- read_file: Understand code and documentation
+- glob: Find relevant files
+
+## CRITICAL Guidelines
+- You have only 3 iterations - be decisive
+- Focus on the specific question asked
+- Consider business value vs effort
+- Identify risks and benefits
+- Give a clear recommendation
+
+## Output Format
+Return a JSON object matching AssessResult:
+{
+  "type": "assess",
+  "businessValue": "low|medium|high",
+  "risks": ["risk1", "risk2"],
+  "benefits": ["benefit1", "benefit2"],
+  "recommendation": "Clear recommendation",
+  "summary": "Assessment summary"
+}
+
+Think like a product owner. Your assessment guides priorities.`;

--- a/src/agents/prompts/execute.ts
+++ b/src/agents/prompts/execute.ts
@@ -1,0 +1,37 @@
+/**
+ * Execute Agent System Prompt
+ * Implement ONE file or small set of related changes
+ */
+
+export const EXECUTE_PROMPT = `You are a code execution agent.
+
+## Your Mission
+Implement ONE specific file or a small, closely related set of changes.
+
+## Tools Available
+- glob: Find files
+- grep: Search code
+- read_file: Read existing code
+- write_file: Create new files
+- edit_file: Modify existing files
+- bash: Run commands (build, test, etc.)
+
+## CRITICAL Guidelines
+- You have only 5 iterations - be direct
+- Read the relevant file(s) first to understand context
+- Make clean, focused changes
+- Follow existing code patterns and style
+- Verify your changes compile/work if possible
+- Don't over-engineer - do exactly what's asked
+
+## Output Format
+Return a JSON object matching ExecuteResult:
+{
+  "type": "execute",
+  "filesCreated": ["path1", "path2"],
+  "filesModified": ["path3"],
+  "commandsRun": [{"command": "...", "success": true, "output": "..."}],
+  "summary": "What was implemented"
+}
+
+Write clean, working code. Your implementation should be complete and correct.`;

--- a/src/agents/prompts/explore.ts
+++ b/src/agents/prompts/explore.ts
@@ -1,0 +1,33 @@
+/**
+ * Explore Agent System Prompt
+ * Fast, focused codebase exploration - ONE specific search
+ */
+
+export const EXPLORE_PROMPT = `You are a fast codebase exploration agent.
+
+## Your Mission
+Quickly discover and understand ONE specific aspect of code structure.
+
+## Tools Available
+- glob: Find files by pattern
+- grep: Search code for patterns
+- read_file: Read file contents
+
+## CRITICAL Guidelines
+- You have only 3 iterations - be efficient
+- Focus on your SPECIFIC task - don't wander
+- Find files first (glob/grep), then read only the most relevant 1-2
+- Summarize findings concisely
+- NEVER modify anything - observation only
+
+## Output Format
+Return a JSON object matching ExploreResult:
+{
+  "type": "explore",
+  "files": [{"path": "...", "description": "..."}],
+  "directories": [{"path": "...", "purpose": "..."}],
+  "patterns": ["pattern1", "pattern2"],
+  "summary": "Brief summary of findings"
+}
+
+Be thorough but fast. Your findings help the orchestrator make decisions.`;

--- a/src/agents/prompts/plan.ts
+++ b/src/agents/prompts/plan.ts
@@ -1,0 +1,36 @@
+/**
+ * Plan Agent System Prompt
+ * Architectural planning for ONE component/feature
+ */
+
+export const PLAN_PROMPT = `You are an architectural planning agent.
+
+## Your Mission
+Design a clear implementation plan for ONE specific component or feature.
+
+## Tools Available
+- glob: Find relevant files
+- grep: Search for patterns and existing implementations
+- read_file: Understand existing code
+
+## CRITICAL Guidelines
+- You have only 5 iterations - be focused
+- Explore existing patterns BEFORE proposing new ones
+- Consider edge cases and error handling
+- Break the task into clear, atomic steps
+- Identify dependencies and risks
+- Each step should be implementable by a single execute agent
+
+## Output Format
+Return a JSON object matching PlanResult:
+{
+  "type": "plan",
+  "steps": [
+    {"id": 1, "description": "...", "files": ["path1"], "risk": "low|medium|high"}
+  ],
+  "dependencies": ["dep1", "dep2"],
+  "considerations": ["edge case 1", "..."],
+  "summary": "Brief plan overview"
+}
+
+Think like an architect. Your plan guides the implementation.`;

--- a/src/agents/prompts/refactor.ts
+++ b/src/agents/prompts/refactor.ts
@@ -1,0 +1,35 @@
+/**
+ * Refactor Agent System Prompt
+ * Address ONE specific code quality issue
+ */
+
+export const REFACTOR_PROMPT = `You are a code refactoring agent.
+
+## Your Mission
+Address ONE specific code quality issue or improvement.
+
+## Tools Available
+- glob: Find files to refactor
+- grep: Search for patterns
+- read_file: Understand current code
+- edit_file: Make targeted changes
+
+## CRITICAL Guidelines
+- You have only 4 iterations - stay focused
+- Focus on ONE specific issue
+- Preserve existing functionality
+- Follow existing code patterns
+- Make minimal, clean changes
+- Don't introduce new features
+
+## Output Format
+Return a JSON object matching RefactorResult:
+{
+  "type": "refactor",
+  "issues": [{"file": "...", "line": 42, "issue": "...", "severity": "info|warning|error"}],
+  "suggestions": ["suggestion1"],
+  "filesModified": ["path1"],
+  "summary": "What was refactored"
+}
+
+Improve code quality surgically. Less is more.`;

--- a/src/agents/prompts/research.ts
+++ b/src/agents/prompts/research.ts
@@ -1,0 +1,32 @@
+/**
+ * Research Agent System Prompt
+ * Single web search query with focused results
+ */
+
+export const RESEARCH_PROMPT = `You are a web research agent.
+
+## Your Mission
+Find specific information from the web for ONE focused query.
+
+## Tools Available
+- web_search: Search the web for information
+- web_fetch: Fetch and read a specific URL
+- read_file: Read local documentation if needed
+
+## CRITICAL Guidelines
+- You have only 4 iterations - be precise
+- Make ONE focused search query
+- Fetch only the most relevant 1-2 pages
+- Extract the key information needed
+- Cite your sources
+
+## Output Format
+Return a JSON object matching ResearchResult:
+{
+  "type": "research",
+  "sources": [{"url": "...", "title": "...", "relevance": "..."}],
+  "findings": ["finding1", "finding2"],
+  "summary": "Key takeaways"
+}
+
+Be a focused researcher. Find exactly what's needed, nothing more.`;

--- a/src/agents/prompts/verify.ts
+++ b/src/agents/prompts/verify.ts
@@ -1,0 +1,34 @@
+/**
+ * Verify Agent System Prompt
+ * Run ONE test suite or validation check
+ */
+
+export const VERIFY_PROMPT = `You are a verification agent.
+
+## Your Mission
+Validate code changes by running ONE specific test suite or check.
+
+## Tools Available
+- bash: Run tests, builds, linters
+- read_file: Examine test files and outputs
+- glob: Find test files
+
+## CRITICAL Guidelines
+- You have only 4 iterations - be efficient
+- Run the specific tests requested
+- Read test output carefully
+- Report clear pass/fail status
+- Note any regressions or issues
+
+## Output Format
+Return a JSON object matching VerifyResult:
+{
+  "type": "verify",
+  "tests": [{"name": "...", "passed": true/false, "output": "..."}],
+  "coverage": 85.5,
+  "issues": ["issue1", "issue2"],
+  "passed": true/false,
+  "summary": "Verification summary"
+}
+
+Be thorough but fast. Your verification ensures quality.`;

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -1,0 +1,213 @@
+/**
+ * Sub-Agent Runner
+ * Executes a single sub-agent with isolated context and tool filtering
+ */
+
+import type { Message, ToolCall } from "../llm/client.ts";
+import { client } from "../llm/client.ts";
+import { tools as allTools } from "../llm/prompts.ts";
+import { executeTool } from "../tools/index.ts";
+import { getAgentConfig, filterToolsForAgent } from "./index.ts";
+import type {
+  SubAgentTask,
+  SubAgentCallbacks,
+  AgentResult,
+  AgentType,
+} from "./types.ts";
+
+const DEBUG = process.env.DEBUG === "1";
+
+/**
+ * Run a sub-agent with isolated context
+ * Returns structured result when complete
+ */
+export async function runSubAgent(
+  task: SubAgentTask,
+  callbacks: SubAgentCallbacks
+): Promise<AgentResult> {
+  const config = getAgentConfig(task.agentType);
+  const filteredTools = filterToolsForAgent(allTools, task.agentType);
+
+  // Isolated message context for this sub-agent
+  const messages: Message[] = [
+    { role: "system", content: config.systemPrompt },
+    { role: "user", content: task.prompt },
+  ];
+
+  let iterations = 0;
+  let lastContent = "";
+
+  callbacks.onProgress(`Starting ${config.name}...`);
+
+  while (iterations < config.maxIterations) {
+    iterations++;
+
+    if (DEBUG) {
+      console.error(
+        `\n[DEBUG] ${config.name} iteration ${iterations}/${config.maxIterations}`
+      );
+    }
+
+    try {
+      const { content, toolCalls } = await getResponse(
+        messages,
+        filteredTools,
+        callbacks
+      );
+
+      // Add assistant message
+      const assistantMessage: Message = {
+        role: "assistant",
+        content: content || "",
+        tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+      };
+      messages.push(assistantMessage);
+
+      lastContent = content || lastContent;
+
+      // If no tool calls, agent is done
+      if (toolCalls.length === 0) {
+        break;
+      }
+
+      // Execute tool calls
+      for (const toolCall of toolCalls) {
+        const argsJson = JSON.stringify(toolCall.function.arguments);
+        callbacks.onToolCall(toolCall.function.name, argsJson);
+
+        const result = await executeTool(toolCall.function.name, argsJson);
+
+        // Add tool result to messages
+        messages.push({
+          role: "tool",
+          content: result.output,
+          tool_call_id: toolCall.id,
+        });
+      }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      callbacks.onProgress(`Error: ${errorMsg}`);
+      throw error;
+    }
+  }
+
+  // Extract and parse the structured result
+  return extractResult(task.agentType, lastContent, messages);
+}
+
+/**
+ * Get LLM response (non-streaming for sub-agents to reduce complexity)
+ */
+async function getResponse(
+  messages: Message[],
+  tools: typeof allTools,
+  callbacks: SubAgentCallbacks
+): Promise<{ content: string; toolCalls: ToolCall[] }> {
+  const result = await client.chat(messages, tools);
+
+  if (result.content && callbacks.onToken) {
+    callbacks.onToken(result.content);
+  }
+
+  return {
+    content: result.content,
+    toolCalls: result.toolCalls || [],
+  };
+}
+
+/**
+ * Extract structured result from agent's final response
+ */
+function extractResult(
+  agentType: AgentType,
+  content: string,
+  messages: Message[]
+): AgentResult {
+  // Try to parse JSON from the content
+  const jsonMatch = content.match(/\{[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      const parsed = JSON.parse(jsonMatch[0]);
+      // Validate it has the right type
+      if (parsed.type === agentType) {
+        return parsed as AgentResult;
+      }
+    } catch {
+      // Fall through to generate default result
+    }
+  }
+
+  // Generate default result based on agent type
+  return generateDefaultResult(agentType, content, messages);
+}
+
+/**
+ * Generate a default structured result when parsing fails
+ */
+function generateDefaultResult(
+  agentType: AgentType,
+  content: string,
+  messages: Message[]
+): AgentResult {
+  const summary =
+    content.slice(0, 500) || "Agent completed without explicit summary";
+
+  switch (agentType) {
+    case "explore":
+      return {
+        type: "explore",
+        files: [],
+        directories: [],
+        patterns: [],
+        summary,
+      };
+    case "research":
+      return {
+        type: "research",
+        sources: [],
+        findings: [summary],
+        summary,
+      };
+    case "plan":
+      return {
+        type: "plan",
+        steps: [],
+        dependencies: [],
+        considerations: [],
+        summary,
+      };
+    case "execute":
+      return {
+        type: "execute",
+        filesCreated: [],
+        filesModified: [],
+        commandsRun: [],
+        summary,
+      };
+    case "refactor":
+      return {
+        type: "refactor",
+        issues: [],
+        suggestions: [],
+        filesModified: [],
+        summary,
+      };
+    case "assess":
+      return {
+        type: "assess",
+        businessValue: "medium",
+        risks: [],
+        benefits: [],
+        recommendation: summary,
+        summary,
+      };
+    case "verify":
+      return {
+        type: "verify",
+        tests: [],
+        issues: [],
+        passed: true,
+        summary,
+      };
+  }
+}

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -16,6 +16,7 @@ import type {
 } from "./types.ts";
 
 const DEBUG = process.env.DEBUG === "1";
+const MAX_MESSAGES = 50; // Prevent unbounded message growth
 
 /**
  * Run a sub-agent with isolated context
@@ -70,20 +71,29 @@ export async function runSubAgent(
         break;
       }
 
-      // Execute tool calls
-      for (const toolCall of toolCalls) {
+      // Execute tool calls in parallel
+      const toolPromises = toolCalls.map(async (toolCall, index) => {
         const argsJson = JSON.stringify(toolCall.function.arguments);
         callbacks.onToolCall(toolCall.function.name, argsJson);
-
         const result = await executeTool(toolCall.function.name, argsJson);
+        return { result, toolCall, index };
+      });
 
-        // Add tool result to messages
-        messages.push({
-          role: "tool",
-          content: result.output,
-          tool_call_id: toolCall.id,
+      const toolResults = await Promise.all(toolPromises);
+
+      // Append results in original order to maintain message consistency
+      toolResults
+        .sort((a, b) => a.index - b.index)
+        .forEach(({ result, toolCall }) => {
+          messages.push({
+            role: "tool",
+            content: result.output,
+            tool_call_id: toolCall.id,
+          });
         });
-      }
+
+      // Prune messages if exceeding limit
+      pruneMessages(messages, MAX_MESSAGES);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       callbacks.onProgress(`Error: ${errorMsg}`);
@@ -116,6 +126,66 @@ async function getResponse(
 }
 
 /**
+ * Extract the first balanced JSON object from content.
+ * Uses a brace-depth scanner to handle nested objects correctly.
+ */
+function extractFirstJsonObject(content: string): string | null {
+  const startIdx = content.indexOf("{");
+  if (startIdx === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = startIdx; i < content.length; i++) {
+    const char = content[i];
+
+    if (escape) {
+      escape = false;
+      continue;
+    }
+
+    if (char === "\\" && inString) {
+      escape = true;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (!inString) {
+      if (char === "{") depth++;
+      else if (char === "}") {
+        depth--;
+        if (depth === 0) {
+          return content.slice(startIdx, i + 1);
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Prune messages to prevent unbounded growth.
+ * Keeps system prompt, user prompt, and most recent messages.
+ */
+function pruneMessages(messages: Message[], maxMessages: number): void {
+  if (messages.length <= maxMessages) return;
+
+  // Keep: system prompt (index 0), user prompt (index 1), last N messages
+  const systemPrompt = messages[0];
+  const userPrompt = messages[1];
+  const keepCount = maxMessages - 2;
+  const recentMessages = messages.slice(-keepCount);
+
+  messages.length = 0;
+  messages.push(systemPrompt, userPrompt, ...recentMessages);
+}
+
+/**
  * Extract structured result from agent's final response
  */
 function extractResult(
@@ -123,11 +193,11 @@ function extractResult(
   content: string,
   messages: Message[]
 ): AgentResult {
-  // Try to parse JSON from the content
-  const jsonMatch = content.match(/\{[\s\S]*\}/);
-  if (jsonMatch) {
+  // Try to parse JSON from the content using balanced brace extraction
+  const jsonStr = extractFirstJsonObject(content);
+  if (jsonStr) {
     try {
-      const parsed = JSON.parse(jsonMatch[0]);
+      const parsed = JSON.parse(jsonStr);
       // Validate it has the right type
       if (parsed.type === agentType) {
         return parsed as AgentResult;

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -150,7 +150,7 @@ export function isVerifyResult(result: AgentResult): result is VerifyResult {
   return result.type === "verify";
 }
 
-// Generate unique task ID
+// Generate unique task ID using cryptographically secure random UUID
 export function generateTaskId(): string {
-  return Math.random().toString(36).substring(2, 7);
+  return crypto.randomUUID();
 }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,0 +1,156 @@
+/**
+ * Agent Type System
+ * Defines types for sub-agents with structured results
+ */
+
+export type AgentType =
+  | "explore"
+  | "research"
+  | "plan"
+  | "execute"
+  | "refactor"
+  | "assess"
+  | "verify";
+
+export interface AgentConfig {
+  type: AgentType;
+  name: string;
+  description: string;
+  systemPrompt: string;
+  allowedTools: string[];
+  maxIterations: number;
+}
+
+export interface SubAgentTask {
+  id: string;
+  agentType: AgentType;
+  prompt: string;
+  status: "pending" | "running" | "completed" | "failed";
+  result?: AgentResult;
+  error?: string;
+  startedAt?: number;
+  completedAt?: number;
+}
+
+// Structured result types per agent - enforces small, focused outputs
+
+export interface ExploreResult {
+  type: "explore";
+  files: { path: string; description: string }[];
+  directories: { path: string; purpose: string }[];
+  patterns: string[];
+  summary: string;
+}
+
+export interface ResearchResult {
+  type: "research";
+  sources: { url: string; title: string; relevance: string }[];
+  findings: string[];
+  summary: string;
+}
+
+export interface PlanResult {
+  type: "plan";
+  steps: {
+    id: number;
+    description: string;
+    files: string[];
+    risk: "low" | "medium" | "high";
+  }[];
+  dependencies: string[];
+  considerations: string[];
+  summary: string;
+}
+
+export interface ExecuteResult {
+  type: "execute";
+  filesCreated: string[];
+  filesModified: string[];
+  commandsRun: { command: string; success: boolean; output?: string }[];
+  summary: string;
+}
+
+export interface RefactorResult {
+  type: "refactor";
+  issues: {
+    file: string;
+    line?: number;
+    issue: string;
+    severity: "info" | "warning" | "error";
+  }[];
+  suggestions: string[];
+  filesModified: string[];
+  summary: string;
+}
+
+export interface AssessResult {
+  type: "assess";
+  businessValue: "low" | "medium" | "high";
+  risks: string[];
+  benefits: string[];
+  recommendation: string;
+  summary: string;
+}
+
+export interface VerifyResult {
+  type: "verify";
+  tests: { name: string; passed: boolean; output?: string }[];
+  coverage?: number;
+  issues: string[];
+  passed: boolean;
+  summary: string;
+}
+
+export type AgentResult =
+  | ExploreResult
+  | ResearchResult
+  | PlanResult
+  | ExecuteResult
+  | RefactorResult
+  | AssessResult
+  | VerifyResult;
+
+// Callbacks for agent execution progress
+export interface SubAgentCallbacks {
+  onProgress: (message: string) => void;
+  onToolCall: (tool: string, args: string) => void;
+  onToken?: (token: string) => void;
+}
+
+// Utility type guards
+export function isExploreResult(result: AgentResult): result is ExploreResult {
+  return result.type === "explore";
+}
+
+export function isResearchResult(
+  result: AgentResult
+): result is ResearchResult {
+  return result.type === "research";
+}
+
+export function isPlanResult(result: AgentResult): result is PlanResult {
+  return result.type === "plan";
+}
+
+export function isExecuteResult(result: AgentResult): result is ExecuteResult {
+  return result.type === "execute";
+}
+
+export function isRefactorResult(
+  result: AgentResult
+): result is RefactorResult {
+  return result.type === "refactor";
+}
+
+export function isAssessResult(result: AgentResult): result is AssessResult {
+  return result.type === "assess";
+}
+
+export function isVerifyResult(result: AgentResult): result is VerifyResult {
+  return result.type === "verify";
+}
+
+// Generate unique task ID
+export function generateTaskId(): string {
+  return Math.random().toString(36).substring(2, 7);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env bun
 /**
  * Nemotron CLI - A coding agent powered by NVIDIA Nemotron 3 Nano
+ * With sub-agent orchestration capabilities
  */
 
 import * as p from "@clack/prompts";
 import type { Message } from "./llm/client.ts";
-import { client } from "./llm/client.ts";
+import { client, initClient } from "./llm/client.ts";
 import { runAgent, type AgentCallbacks } from "./agent/loop.ts";
 import { Spinner, colorize } from "./ui/spinner.ts";
 import {
@@ -16,6 +17,10 @@ import {
   renderError,
   StreamBuffer,
 } from "./ui/render.ts";
+import { setSpawnAgentHandler } from "./tools/index.ts";
+import { ParallelAgentExecutor } from "./agents/parallel.ts";
+import { AgentRenderer } from "./ui/agents.ts";
+import type { AgentType } from "./agents/types.ts";
 
 async function main() {
   // Parse CLI args
@@ -31,17 +36,34 @@ ${colorize("Usage:", "dim")}
 ${colorize("Options:", "dim")}
   --help, -h     Show this help message
   --version, -v  Show version
+  --cloud        Use cloud-routed model (default: local)
 
 ${colorize("Requirements:", "dim")}
   - Ollama running (ollama serve)
   - Model downloaded (ollama pull nemotron-3-nano:30b)
+
+${colorize("Sub-Agents:", "dim")}
+  The orchestrator can delegate to specialized sub-agents:
+  - explore: Fast codebase exploration
+  - research: Web search and documentation
+  - plan: Architectural planning
+  - execute: Code implementation
+  - refactor: Code quality improvements
+  - assess: Business value assessment
+  - verify: Testing and validation
 `);
     process.exit(0);
   }
 
   if (args.includes("--version") || args.includes("-v")) {
-    console.log("nemotron-cli v0.1.0");
+    console.log("nemotron-cli v0.2.0");
     process.exit(0);
+  }
+
+  // Handle --cloud flag: use cloud-routed model variant
+  const useCloud = args.includes("--cloud");
+  if (useCloud) {
+    initClient({ model: "nemotron-3-nano:30b-cloud" });
   }
 
   // Check Ollama connection
@@ -57,8 +79,37 @@ ${colorize("Requirements:", "dim")}
     process.exit(1);
   }
 
+  // Initialize agent renderer and executor
+  const agentRenderer = new AgentRenderer();
+  const agentExecutor = new ParallelAgentExecutor({
+    onAgentStart: (taskId, type) => agentRenderer.startAgent(taskId, type),
+    onAgentProgress: (taskId, msg) => agentRenderer.updateProgress(taskId, msg),
+    onAgentToolCall: (taskId, tool, args) =>
+      agentRenderer.showToolCall(taskId, tool, args),
+    onAgentComplete: (taskId, result) =>
+      agentRenderer.completeAgent(taskId, result),
+    onAgentError: (taskId, error) => agentRenderer.failAgent(taskId, error),
+  });
+
+  // Set up spawn_agent handler to use our executor
+  setSpawnAgentHandler(async (agentType: AgentType, prompt: string) => {
+    return agentExecutor.spawn(agentType, prompt);
+  });
+
   // Show welcome
   renderWelcome();
+  console.log(
+    colorize(
+      `  Model: ${client.modelName} (${useCloud ? "cloud" : "local"})`,
+      "dim"
+    )
+  );
+  console.log(
+    colorize(
+      "  Sub-agents enabled: explore, research, plan, execute, refactor, assess, verify\n",
+      "dim"
+    )
+  );
 
   // Conversation history
   let history: Message[] = [];
@@ -89,6 +140,31 @@ ${colorize("Requirements:", "dim")}
       history = [];
       console.clear();
       renderWelcome();
+      console.log(
+        colorize(
+          "  Sub-agents enabled: explore, research, plan, execute, refactor, assess, verify\n",
+          "dim"
+        )
+      );
+      continue;
+    }
+
+    if (userInput.toLowerCase() === "agents") {
+      const status = agentExecutor.getStatus();
+      if (status.length === 0) {
+        console.log(colorize("\nNo active agents.\n", "dim"));
+      } else {
+        console.log(colorize("\nActive agents:", "cyan"));
+        for (const task of status) {
+          const elapsed = task.startedAt
+            ? ((Date.now() - task.startedAt) / 1000).toFixed(1)
+            : "?";
+          console.log(
+            `  ${task.agentType} [${task.id.slice(0, 5)}] - ${task.status} (${elapsed}s)`
+          );
+        }
+        console.log();
+      }
       continue;
     }
 
@@ -99,7 +175,7 @@ ${colorize("Requirements:", "dim")}
 
     const callbacks: AgentCallbacks = {
       onThinking: () => {
-        if (!isStreaming) {
+        if (!isStreaming && !agentRenderer.isRunning()) {
           thinkingSpinner.start();
         }
       },
@@ -119,14 +195,21 @@ ${colorize("Requirements:", "dim")}
           isStreaming = false;
         }
         thinkingSpinner.stop();
-        renderToolCall(name, args);
-        thinkingSpinner.update(`Running ${name}...`);
-        thinkingSpinner.start();
+
+        // spawn_agent is handled by the agent renderer
+        if (name !== "spawn_agent") {
+          renderToolCall(name, args);
+          thinkingSpinner.update(`Running ${name}...`);
+          thinkingSpinner.start();
+        }
       },
 
       onToolResult: (name, result, success) => {
         thinkingSpinner.stop();
-        renderToolResult(name, result, success);
+        // spawn_agent results are rendered by agent renderer
+        if (name !== "spawn_agent") {
+          renderToolResult(name, result, success);
+        }
       },
 
       onComplete: () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,26 @@ ${colorize("Sub-Agents:", "dim")}
     return agentExecutor.spawn(agentType, prompt);
   });
 
+  // Register cleanup handlers for process exit
+  const cleanup = () => {
+    agentRenderer.dispose();
+  };
+
+  process.on("exit", cleanup);
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("uncaughtException", (error) => {
+    console.error("Uncaught exception:", error);
+    cleanup();
+    process.exit(1);
+  });
+
   // Show welcome
   renderWelcome();
   console.log(

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -228,4 +228,8 @@ export class OllamaClient {
   }
 }
 
-export const client = new OllamaClient();
+export let client = new OllamaClient();
+
+export function initClient(config: Partial<OllamaClientConfig>): void {
+  client = new OllamaClient(config);
+}

--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -1,30 +1,100 @@
 import type { Tool } from "./client.ts";
 
-export const SYSTEM_PROMPT = `You are an autonomous coding agent with access to tools. You MUST use tools to complete tasks - do not just describe what you would do.
+export const SYSTEM_PROMPT = `You are an autonomous coding agent that orchestrates specialized sub-agents.
 
-## CRITICAL: You have these tools - USE THEM:
-- read_file(path): Read file contents - USE THIS to see what's in files
-- write_file(path, content): Create/overwrite files - USE THIS to write code
-- edit_file(path, search, replace): Edit files - USE THIS for targeted changes
-- bash(command): Run shell commands - USE THIS for git, npm, tests, etc.
-- glob(pattern): Find files - USE THIS to discover files (e.g., "**/*.ts")
-- grep(pattern, path): Search code - USE THIS to find text in files
+## CRITICAL: Minimal Context by Decomposition
+- ALWAYS decompose tasks into the SMALLEST possible sub-agent scopes
+- Spawn MANY focused agents rather than FEW broad agents
+- Each agent should do ONE thing well
+- NEVER ask an agent to do more than 3-5 iterations of work
+- Maximize parallelism by spawning independent agents simultaneously
 
-## IMPORTANT BEHAVIORS:
-1. When asked to do something, USE THE TOOLS IMMEDIATELY - don't ask clarifying questions unless absolutely necessary
-2. When asked about files, USE glob or read_file to look at them first
-3. When asked to edit/modify, USE read_file first, then edit_file or write_file
-4. When asked to run commands, USE bash
-5. NEVER say "I would do X" - actually DO IT with tools
+## Available Tools
+Direct tools (for simple, 1-2 step operations):
+- read_file(path): Read file contents
+- write_file(path, content): Create/overwrite files
+- edit_file(path, search, replace): Edit files
+- bash(command): Run shell commands
+- glob(pattern): Find files
+- grep(pattern, path): Search code
 
-## Example: If user says "edit the readme", you should:
-1. Call glob("**/README*") to find README files
-2. Call read_file on the found file
-3. Call edit_file or write_file to make changes
+Sub-agent delegation (for complex, multi-step tasks):
+- spawn_agent(agent_type, prompt): Delegate to specialized agent
 
-Be proactive. Take action. Use your tools.`;
+## Sub-Agent Types
+- explore: Fast, focused file discovery - ONE specific search
+- research: Single web search query with focused results
+- plan: Design plan for ONE component/feature
+- execute: Implement ONE file or small set of related changes
+- refactor: Address ONE specific code quality issue
+- assess: Evaluate ONE specific decision or feature
+- verify: Run ONE test suite or validation check
+
+## Decomposition Examples
+BAD: spawn explore agent with "understand the entire codebase"
+GOOD: spawn 5 explore agents in parallel:
+  - "find all TypeScript entry points"
+  - "find configuration files"
+  - "find test files and patterns"
+  - "find API route handlers"
+  - "find shared utilities"
+
+BAD: spawn execute agent with "implement user authentication"
+GOOD: spawn multiple execute agents sequentially:
+  - "create User model in src/models/user.ts"
+  - "create auth middleware in src/middleware/auth.ts"
+  - "add login route to src/routes/auth.ts"
+
+## When to use sub-agents vs direct tools
+- Use sub-agents for ANY task requiring more than 1-2 tool calls
+- Use direct tools only for trivial, single-step operations
+- Spawn multiple agents simultaneously when tasks are independent
+
+## Orchestration Pattern
+1. Understand the user's request
+2. Decompose into SMALLEST possible sub-tasks
+3. Identify which can run in parallel vs sequential
+4. Spawn parallel agents simultaneously
+5. Synthesize results
+6. Present coherent response to user
+
+Be proactive. Delegate effectively. Synthesize results clearly.`;
 
 export const tools: Tool[] = [
+  {
+    type: "function",
+    function: {
+      name: "spawn_agent",
+      description: `Spawn a specialized sub-agent to handle a specific task. Use this for complex tasks that need focused attention.
+
+Available agent types:
+- explore: Fast codebase exploration, file discovery (3 iterations max)
+- research: Web search, documentation lookup (4 iterations max)
+- plan: Architectural design, implementation planning (5 iterations max)
+- execute: Code implementation, file modifications (5 iterations max)
+- refactor: Code quality, integration coherence (4 iterations max)
+- assess: Business logic & value assessment (3 iterations max)
+- verify: Testing, validation, E2E (4 iterations max)
+
+IMPORTANT: Keep prompts focused and specific. Each agent should do ONE thing well.`,
+      parameters: {
+        type: "object",
+        properties: {
+          agent_type: {
+            type: "string",
+            description:
+              "The type of specialized agent to spawn: explore, research, plan, execute, refactor, assess, verify",
+          },
+          prompt: {
+            type: "string",
+            description:
+              "Specific, focused instructions for the sub-agent. Keep it narrow in scope.",
+          },
+        },
+        required: ["agent_type", "prompt"],
+      },
+    },
+  },
   {
     type: "function",
     function: {
@@ -148,6 +218,42 @@ export const tools: Tool[] = [
           },
         },
         required: ["pattern"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "web_search",
+      description:
+        "Search the web for information. Returns top search results with titles, URLs, and snippets.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "The search query",
+          },
+        },
+        required: ["query"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "web_fetch",
+      description:
+        "Fetch and read content from a URL. Converts HTML to readable text.",
+      parameters: {
+        type: "object",
+        properties: {
+          url: {
+            type: "string",
+            description: "The URL to fetch (must start with http:// or https://)",
+          },
+        },
+        required: ["url"],
       },
     },
   },

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,8 @@ import { webSearch, webFetch } from "./web.ts";
 import type { AgentType, AgentResult } from "../agents/types.ts";
 import { isValidAgentType } from "../agents/index.ts";
 
+const MAX_PROMPT_LENGTH = 8192; // 8KB limit for agent prompts
+
 export type ToolResult = {
   success: boolean;
   output: string;
@@ -49,6 +51,12 @@ const toolHandlers: Record<string, ToolHandler> = {
     if (!isValidAgentType(agentType)) {
       throw new Error(
         `Invalid agent type: ${agentType}. Valid types: explore, research, plan, execute, refactor, assess, verify`
+      );
+    }
+
+    if (prompt.length > MAX_PROMPT_LENGTH) {
+      throw new Error(
+        `Prompt exceeds maximum length of ${MAX_PROMPT_LENGTH} characters (got ${prompt.length}). Consider breaking into smaller tasks.`
       );
     }
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,6 +5,9 @@
 import { readFile, writeFile, editFile } from "./file.ts";
 import { bash } from "./bash.ts";
 import { glob, grep } from "./search.ts";
+import { webSearch, webFetch } from "./web.ts";
+import type { AgentType, AgentResult } from "../agents/types.ts";
+import { isValidAgentType } from "../agents/index.ts";
 
 export type ToolResult = {
   success: boolean;
@@ -13,7 +16,52 @@ export type ToolResult = {
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<string>;
 
+// Agent spawn handler - set from main loop to integrate with TUI
+let spawnAgentHandler:
+  | ((agentType: AgentType, prompt: string) => Promise<AgentResult>)
+  | null = null;
+
+/**
+ * Set the spawn_agent handler (called from main loop setup)
+ */
+export function setSpawnAgentHandler(
+  handler: (agentType: AgentType, prompt: string) => Promise<AgentResult>
+): void {
+  spawnAgentHandler = handler;
+}
+
+/**
+ * Check if spawn_agent is available
+ */
+export function isSpawnAgentAvailable(): boolean {
+  return spawnAgentHandler !== null;
+}
+
 const toolHandlers: Record<string, ToolHandler> = {
+  spawn_agent: async (args) => {
+    const agentType = args.agent_type as string;
+    const prompt = args.prompt as string;
+
+    if (!agentType || !prompt) {
+      throw new Error("spawn_agent requires agent_type and prompt");
+    }
+
+    if (!isValidAgentType(agentType)) {
+      throw new Error(
+        `Invalid agent type: ${agentType}. Valid types: explore, research, plan, execute, refactor, assess, verify`
+      );
+    }
+
+    if (!spawnAgentHandler) {
+      throw new Error(
+        "spawn_agent not available - agent context not initialized"
+      );
+    }
+
+    const result = await spawnAgentHandler(agentType as AgentType, prompt);
+    return JSON.stringify(result, null, 2);
+  },
+
   read_file: async (args) => {
     return readFile(args.path as string);
   },
@@ -40,6 +88,14 @@ const toolHandlers: Record<string, ToolHandler> = {
 
   grep: async (args) => {
     return grep(args.pattern as string, args.path as string | undefined);
+  },
+
+  web_search: async (args) => {
+    return webSearch(args.query as string);
+  },
+
+  web_fetch: async (args) => {
+    return webFetch(args.url as string);
   },
 };
 
@@ -71,9 +127,8 @@ export function formatToolCall(name: string, argsJson: string): string {
     const args = JSON.parse(argsJson) as Record<string, unknown>;
     const argStr = Object.entries(args)
       .map(([k, v]) => {
-        const val = typeof v === "string" && v.length > 50
-          ? v.slice(0, 50) + "..."
-          : v;
+        const val =
+          typeof v === "string" && v.length > 50 ? v.slice(0, 50) + "..." : v;
         return `${k}: ${JSON.stringify(val)}`;
       })
       .join(", ");

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -7,6 +7,35 @@ const MAX_CONTENT_SIZE = 50000; // 50KB limit for fetched content
 const SEARCH_TIMEOUT = 10000; // 10 seconds
 const FETCH_TIMEOUT = 15000; // 15 seconds
 
+// SSRF Protection: Block private/local addresses
+const BLOCKED_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "::1",
+  "169.254.169.254", // AWS metadata
+]);
+
+const PRIVATE_IP_RANGES = [
+  /^127\./, // 127.0.0.0/8
+  /^10\./, // 10.0.0.0/8
+  /^172\.(1[6-9]|2[0-9]|3[01])\./, // 172.16.0.0/12
+  /^192\.168\./, // 192.168.0.0/16
+  /^169\.254\./, // 169.254.0.0/16
+  /^\[?::1\]?$/, // IPv6 loopback
+  /^\[?fe80:/i, // IPv6 link-local
+  /^\[?fc00:/i, // IPv6 private
+];
+
+/**
+ * Check if a hostname is blocked (private/local address)
+ */
+function isBlockedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  if (BLOCKED_HOSTS.has(host)) return true;
+  return PRIVATE_IP_RANGES.some((pattern) => pattern.test(host));
+}
+
 /**
  * Search the web using DuckDuckGo HTML API (no API key required)
  */
@@ -48,47 +77,63 @@ export async function webSearch(query: string): Promise<string> {
 
 /**
  * Parse DuckDuckGo HTML search results
+ * NOTE: This uses regex to parse DuckDuckGo HTML. May break on layout changes.
+ * TODO: Consider switching to a proper HTML parser (cheerio/jsdom) for robustness.
  */
 function parseSearchResults(html: string): string {
   const results: { title: string; url: string; snippet: string }[] = [];
 
-  // Match result blocks - DuckDuckGo uses <a class="result__a"> for titles
-  const resultPattern =
-    /<a[^>]*class="result__a"[^>]*href="([^"]*)"[^>]*>([^<]*)<\/a>[\s\S]*?<a[^>]*class="result__snippet"[^>]*>([^<]*)<\/a>/g;
+  try {
+    // Match result blocks - DuckDuckGo uses <a class="result__a"> for titles
+    const resultPattern =
+      /<a[^>]*class="result__a"[^>]*href="([^"]*)"[^>]*>([^<]*)<\/a>[\s\S]*?<a[^>]*class="result__snippet"[^>]*>([^<]*)<\/a>/g;
 
-  let match;
-  while ((match = resultPattern.exec(html)) !== null && results.length < 10) {
-    const [, url, title, snippet] = match;
-    if (url && title) {
-      results.push({
-        title: decodeHtmlEntities(title.trim()),
-        url: decodeUrl(url),
-        snippet: decodeHtmlEntities(snippet?.trim() || ""),
-      });
-    }
-  }
-
-  // Fallback: try simpler pattern if no results
-  if (results.length === 0) {
-    const simplePattern = /<a[^>]*href="(https?:\/\/[^"]+)"[^>]*>([^<]+)<\/a>/g;
-    while (
-      (match = simplePattern.exec(html)) !== null &&
-      results.length < 10
-    ) {
-      const [, url, title] = match;
-      if (
-        url &&
-        title &&
-        !url.includes("duckduckgo.com") &&
-        title.trim().length > 10
-      ) {
-        results.push({
-          title: decodeHtmlEntities(title.trim()),
-          url: url,
-          snippet: "",
-        });
+    let match;
+    while ((match = resultPattern.exec(html)) !== null && results.length < 10) {
+      const [, url, title, snippet] = match;
+      if (url && title) {
+        try {
+          results.push({
+            title: decodeHtmlEntities(title.trim()),
+            url: decodeUrl(url),
+            snippet: decodeHtmlEntities(snippet?.trim() || ""),
+          });
+        } catch {
+          // Skip malformed results
+        }
       }
     }
+
+    // Fallback: try simpler pattern if no results
+    if (results.length === 0) {
+      const simplePattern =
+        /<a[^>]*href="(https?:\/\/[^"]+)"[^>]*>([^<]+)<\/a>/g;
+      while (
+        (match = simplePattern.exec(html)) !== null &&
+        results.length < 10
+      ) {
+        const [, url, title] = match;
+        if (
+          url &&
+          title &&
+          !url.includes("duckduckgo.com") &&
+          title.trim().length > 10
+        ) {
+          try {
+            results.push({
+              title: decodeHtmlEntities(title.trim()),
+              url: url,
+              snippet: "",
+            });
+          } catch {
+            // Skip malformed results
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.error("[parseSearchResults] Failed to parse HTML:", error);
+    return "Failed to parse search results. The search provider may have changed their format.";
   }
 
   if (results.length === 0) {
@@ -109,6 +154,14 @@ function parseSearchResults(html: string): string {
 export async function webFetch(url: string): Promise<string> {
   if (!url || !url.startsWith("http")) {
     throw new Error("Invalid URL - must start with http:// or https://");
+  }
+
+  // SSRF protection: block private/local addresses
+  const parsedUrl = new URL(url);
+  if (isBlockedHost(parsedUrl.hostname)) {
+    throw new Error(
+      `Blocked: Cannot fetch from private/local address: ${parsedUrl.hostname}`
+    );
   }
 
   const controller = new AbortController();

--- a/src/tools/web.ts
+++ b/src/tools/web.ts
@@ -1,0 +1,226 @@
+/**
+ * Web tools for Research agent
+ * Provides web search and fetch capabilities
+ */
+
+const MAX_CONTENT_SIZE = 50000; // 50KB limit for fetched content
+const SEARCH_TIMEOUT = 10000; // 10 seconds
+const FETCH_TIMEOUT = 15000; // 15 seconds
+
+/**
+ * Search the web using DuckDuckGo HTML API (no API key required)
+ */
+export async function webSearch(query: string): Promise<string> {
+  if (!query || query.trim().length === 0) {
+    throw new Error("Search query cannot be empty");
+  }
+
+  const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SEARCH_TIMEOUT);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (compatible; NemotronCLI/1.0; +https://github.com/nemotron-cli)",
+      },
+    });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      throw new Error(`Search failed: ${response.status} ${response.statusText}`);
+    }
+
+    const html = await response.text();
+    return parseSearchResults(html);
+  } catch (error) {
+    clearTimeout(timeout);
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("Search timed out");
+    }
+    throw error;
+  }
+}
+
+/**
+ * Parse DuckDuckGo HTML search results
+ */
+function parseSearchResults(html: string): string {
+  const results: { title: string; url: string; snippet: string }[] = [];
+
+  // Match result blocks - DuckDuckGo uses <a class="result__a"> for titles
+  const resultPattern =
+    /<a[^>]*class="result__a"[^>]*href="([^"]*)"[^>]*>([^<]*)<\/a>[\s\S]*?<a[^>]*class="result__snippet"[^>]*>([^<]*)<\/a>/g;
+
+  let match;
+  while ((match = resultPattern.exec(html)) !== null && results.length < 10) {
+    const [, url, title, snippet] = match;
+    if (url && title) {
+      results.push({
+        title: decodeHtmlEntities(title.trim()),
+        url: decodeUrl(url),
+        snippet: decodeHtmlEntities(snippet?.trim() || ""),
+      });
+    }
+  }
+
+  // Fallback: try simpler pattern if no results
+  if (results.length === 0) {
+    const simplePattern = /<a[^>]*href="(https?:\/\/[^"]+)"[^>]*>([^<]+)<\/a>/g;
+    while (
+      (match = simplePattern.exec(html)) !== null &&
+      results.length < 10
+    ) {
+      const [, url, title] = match;
+      if (
+        url &&
+        title &&
+        !url.includes("duckduckgo.com") &&
+        title.trim().length > 10
+      ) {
+        results.push({
+          title: decodeHtmlEntities(title.trim()),
+          url: url,
+          snippet: "",
+        });
+      }
+    }
+  }
+
+  if (results.length === 0) {
+    return "No search results found.";
+  }
+
+  return results
+    .map(
+      (r, i) =>
+        `${i + 1}. ${r.title}\n   URL: ${r.url}\n   ${r.snippet || "(no snippet)"}`
+    )
+    .join("\n\n");
+}
+
+/**
+ * Fetch content from a URL and convert to readable text
+ */
+export async function webFetch(url: string): Promise<string> {
+  if (!url || !url.startsWith("http")) {
+    throw new Error("Invalid URL - must start with http:// or https://");
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (compatible; NemotronCLI/1.0; +https://github.com/nemotron-cli)",
+        Accept: "text/html,application/xhtml+xml,text/plain,*/*",
+      },
+    });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    const html = await response.text();
+
+    // Convert HTML to readable text
+    if (contentType.includes("text/html") || html.includes("<html")) {
+      return htmlToText(html).slice(0, MAX_CONTENT_SIZE);
+    }
+
+    // Return plain text as-is
+    return html.slice(0, MAX_CONTENT_SIZE);
+  } catch (error) {
+    clearTimeout(timeout);
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("Fetch timed out");
+    }
+    throw error;
+  }
+}
+
+/**
+ * Convert HTML to readable text (simple implementation)
+ */
+function htmlToText(html: string): string {
+  // Remove script and style tags
+  let text = html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+    .replace(/<noscript[^>]*>[\s\S]*?<\/noscript>/gi, "");
+
+  // Convert common elements to text
+  text = text
+    // Headers
+    .replace(/<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/gi, "\n\n## $1\n\n")
+    // Paragraphs
+    .replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, "\n$1\n")
+    // Line breaks
+    .replace(/<br\s*\/?>/gi, "\n")
+    // Links - keep href
+    .replace(/<a[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi, "$2 ($1)")
+    // List items
+    .replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, "\n- $1")
+    // Bold/strong
+    .replace(/<(b|strong)[^>]*>([\s\S]*?)<\/(b|strong)>/gi, "**$2**")
+    // Italic/em
+    .replace(/<(i|em)[^>]*>([\s\S]*?)<\/(i|em)>/gi, "_$2_")
+    // Code
+    .replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, "`$1`")
+    // Pre
+    .replace(/<pre[^>]*>([\s\S]*?)<\/pre>/gi, "\n```\n$1\n```\n")
+    // Remove all other tags
+    .replace(/<[^>]+>/g, "");
+
+  // Decode HTML entities
+  text = decodeHtmlEntities(text);
+
+  // Clean up whitespace
+  text = text
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]+/g, " ")
+    .trim();
+
+  return text;
+}
+
+/**
+ * Decode HTML entities
+ */
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&#x([a-fA-F0-9]+);/g, (_, code) =>
+      String.fromCharCode(parseInt(code, 16))
+    );
+}
+
+/**
+ * Decode DuckDuckGo redirect URLs
+ */
+function decodeUrl(url: string): string {
+  // DuckDuckGo wraps URLs in their redirect
+  if (url.includes("uddg=")) {
+    const match = url.match(/uddg=([^&]+)/);
+    if (match && match[1]) {
+      return decodeURIComponent(match[1]);
+    }
+  }
+  return url;
+}

--- a/src/ui/agents.ts
+++ b/src/ui/agents.ts
@@ -64,14 +64,17 @@ export class AgentRenderer {
     const style = AGENT_STYLES[agent.type];
     const shortId = taskId.slice(0, 5);
 
-    // Truncate args for display
-    const displayArgs = args.length > 60 ? args.slice(0, 60) + "..." : args;
+    // Unicode-safe truncation using spread operator to handle multi-byte characters
+    const maxChars = 60;
+    const chars = [...args]; // Spread respects Unicode code points
+    const displayArgs =
+      chars.length > maxChars ? chars.slice(0, maxChars).join("") + "..." : args;
 
     this.clearSpinnerLine();
     console.log(
       colorize(`  [${shortId}] `, "dim") +
-      colorize(`⚡ ${tool}`, style.color) +
-      colorize(`(${displayArgs})`, "dim")
+        colorize(`⚡ ${tool}`, style.color) +
+        colorize(`(${displayArgs})`, "dim")
     );
     this.renderStatusLine();
   }
@@ -201,6 +204,15 @@ export class AgentRenderer {
    */
   getActiveCount(): number {
     return this.activeAgents.size;
+  }
+
+  /**
+   * Clean up resources and restore terminal state.
+   * Call this before process exit to prevent interval leaks.
+   */
+  dispose(): void {
+    this.stopSpinner();
+    this.activeAgents.clear();
   }
 }
 

--- a/src/ui/agents.ts
+++ b/src/ui/agents.ts
@@ -1,0 +1,237 @@
+/**
+ * Agent TUI Renderer
+ * Handles parallel agent display with multiplexed output
+ */
+
+import type { AgentType, SubAgentTask, AgentResult } from "../agents/types.ts";
+import { colorize, colors } from "./spinner.ts";
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+// Agent styles with icons and colors
+const AGENT_STYLES: Record<AgentType, { icon: string; color: keyof typeof colors }> = {
+  explore: { icon: "🔍", color: "cyan" },
+  research: { icon: "📚", color: "magenta" },
+  plan: { icon: "📋", color: "yellow" },
+  execute: { icon: "⚡", color: "green" },
+  refactor: { icon: "🔧", color: "cyan" },
+  assess: { icon: "📊", color: "gray" },
+  verify: { icon: "✅", color: "green" },
+};
+
+export class AgentRenderer {
+  private spinnerIndex = 0;
+  private spinnerInterval: ReturnType<typeof setInterval> | null = null;
+  private activeAgents: Map<string, { type: AgentType; status: string; startTime: number }> = new Map();
+
+  /**
+   * Start tracking a new agent
+   */
+  startAgent(taskId: string, agentType: AgentType): void {
+    const style = AGENT_STYLES[agentType];
+    this.activeAgents.set(taskId, {
+      type: agentType,
+      status: "Starting...",
+      startTime: Date.now(),
+    });
+
+    // Print agent start
+    const shortId = taskId.slice(0, 5);
+    console.log(
+      colorize(`\n${style.icon} [${shortId}] Starting ${agentType} agent...`, style.color)
+    );
+
+    this.startSpinner();
+  }
+
+  /**
+   * Update agent progress
+   */
+  updateProgress(taskId: string, message: string): void {
+    const agent = this.activeAgents.get(taskId);
+    if (agent) {
+      agent.status = message;
+    }
+  }
+
+  /**
+   * Show tool call from agent
+   */
+  showToolCall(taskId: string, tool: string, args: string): void {
+    const agent = this.activeAgents.get(taskId);
+    if (!agent) return;
+
+    const style = AGENT_STYLES[agent.type];
+    const shortId = taskId.slice(0, 5);
+
+    // Truncate args for display
+    const displayArgs = args.length > 60 ? args.slice(0, 60) + "..." : args;
+
+    this.clearSpinnerLine();
+    console.log(
+      colorize(`  [${shortId}] `, "dim") +
+      colorize(`⚡ ${tool}`, style.color) +
+      colorize(`(${displayArgs})`, "dim")
+    );
+    this.renderStatusLine();
+  }
+
+  /**
+   * Mark agent as complete and show result
+   */
+  completeAgent(taskId: string, result: AgentResult): void {
+    const agent = this.activeAgents.get(taskId);
+    if (!agent) return;
+
+    const style = AGENT_STYLES[agent.type];
+    const shortId = taskId.slice(0, 5);
+    const duration = ((Date.now() - agent.startTime) / 1000).toFixed(1);
+
+    this.clearSpinnerLine();
+
+    // Print completion header
+    console.log(
+      colorize(`\n${style.icon} [${shortId}] ${agent.type} `, style.color) +
+      colorize(`✓`, "green") +
+      colorize(` (${duration}s)`, "dim")
+    );
+
+    // Print summary
+    console.log(colorize(`  ${result.summary}`, "dim"));
+
+    this.activeAgents.delete(taskId);
+
+    if (this.activeAgents.size === 0) {
+      this.stopSpinner();
+    } else {
+      this.renderStatusLine();
+    }
+  }
+
+  /**
+   * Mark agent as failed
+   */
+  failAgent(taskId: string, error: Error): void {
+    const agent = this.activeAgents.get(taskId);
+    if (!agent) return;
+
+    const style = AGENT_STYLES[agent.type];
+    const shortId = taskId.slice(0, 5);
+    const duration = ((Date.now() - agent.startTime) / 1000).toFixed(1);
+
+    this.clearSpinnerLine();
+
+    console.log(
+      colorize(`\n${style.icon} [${shortId}] ${agent.type} `, style.color) +
+      colorize(`✗`, "red") +
+      colorize(` (${duration}s)`, "dim")
+    );
+    console.log(colorize(`  Error: ${error.message}`, "red"));
+
+    this.activeAgents.delete(taskId);
+
+    if (this.activeAgents.size === 0) {
+      this.stopSpinner();
+    } else {
+      this.renderStatusLine();
+    }
+  }
+
+  /**
+   * Render the status line showing all active agents
+   */
+  private renderStatusLine(): void {
+    if (this.activeAgents.size === 0) return;
+
+    const statuses = Array.from(this.activeAgents.entries())
+      .map(([id, agent]) => {
+        const style = AGENT_STYLES[agent.type];
+        const shortId = id.slice(0, 5);
+        const elapsed = ((Date.now() - agent.startTime) / 1000).toFixed(1);
+        const frame = SPINNER_FRAMES[this.spinnerIndex];
+        return colorize(`${agent.type}[${shortId}] ${frame} ${elapsed}s`, style.color);
+      })
+      .join(colorize(" │ ", "dim"));
+
+    process.stdout.write(`\r\x1B[K${colorize("Agents: ", "dim")}${statuses}`);
+  }
+
+  /**
+   * Start the spinner animation
+   */
+  private startSpinner(): void {
+    if (this.spinnerInterval) return;
+
+    process.stdout.write("\x1B[?25l"); // Hide cursor
+
+    this.spinnerInterval = setInterval(() => {
+      this.spinnerIndex = (this.spinnerIndex + 1) % SPINNER_FRAMES.length;
+      this.renderStatusLine();
+    }, 100);
+  }
+
+  /**
+   * Stop the spinner
+   */
+  private stopSpinner(): void {
+    if (this.spinnerInterval) {
+      clearInterval(this.spinnerInterval);
+      this.spinnerInterval = null;
+      this.clearSpinnerLine();
+      process.stdout.write("\x1B[?25h"); // Show cursor
+    }
+  }
+
+  /**
+   * Clear the current spinner line
+   */
+  private clearSpinnerLine(): void {
+    process.stdout.write("\r\x1B[K");
+  }
+
+  /**
+   * Check if any agents are running
+   */
+  isRunning(): boolean {
+    return this.activeAgents.size > 0;
+  }
+
+  /**
+   * Get count of active agents
+   */
+  getActiveCount(): number {
+    return this.activeAgents.size;
+  }
+}
+
+/**
+ * Format agent result as pretty JSON for display
+ */
+export function formatAgentResult(result: AgentResult): string {
+  return JSON.stringify(result, null, 2);
+}
+
+/**
+ * Summarize result for quick display
+ */
+export function summarizeResult(result: AgentResult): string {
+  return result.summary;
+}
+
+/**
+ * Render a detailed result pane (for verbose output)
+ */
+export function renderResultPane(taskId: string, agentType: AgentType, result: AgentResult): void {
+  const style = AGENT_STYLES[agentType];
+  const shortId = taskId.slice(0, 5);
+
+  console.log(colorize(`\n╭─ ${agentType} [${shortId}] Result ─────────────────────────────────────────────╮`, style.color));
+
+  const json = JSON.stringify(result, null, 2);
+  const lines = json.split("\n");
+  for (const line of lines) {
+    console.log(colorize(`│ ${line}`, "dim"));
+  }
+
+  console.log(colorize(`╰──────────────────────────────────────────────────────────────────────╯`, style.color));
+}

--- a/test/agents/runner.test.ts
+++ b/test/agents/runner.test.ts
@@ -1,0 +1,174 @@
+import { test, expect, describe } from "bun:test";
+
+// Test the JSON extraction logic
+// We need to replicate the extractFirstJsonObject function for testing since it's not exported
+
+function extractFirstJsonObject(content: string): string | null {
+  const startIdx = content.indexOf("{");
+  if (startIdx === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = startIdx; i < content.length; i++) {
+    const char = content[i];
+
+    if (escape) {
+      escape = false;
+      continue;
+    }
+
+    if (char === "\\" && inString) {
+      escape = true;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (!inString) {
+      if (char === "{") depth++;
+      else if (char === "}") {
+        depth--;
+        if (depth === 0) {
+          return content.slice(startIdx, i + 1);
+        }
+      }
+    }
+  }
+  return null;
+}
+
+describe("extractFirstJsonObject", () => {
+  test("extracts simple JSON object", () => {
+    const content = 'Some text {"type": "explore", "summary": "test"} more text';
+    const result = extractFirstJsonObject(content);
+
+    expect(result).toBe('{"type": "explore", "summary": "test"}');
+    expect(JSON.parse(result!)).toEqual({ type: "explore", summary: "test" });
+  });
+
+  test("extracts nested JSON correctly", () => {
+    const content = `Here is the result: {"type": "plan", "steps": [{"id": 1, "nested": {"deep": true}}], "summary": "done"} end`;
+    const result = extractFirstJsonObject(content);
+
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    expect(parsed.type).toBe("plan");
+    expect(parsed.steps[0].nested.deep).toBe(true);
+  });
+
+  test("handles braces inside strings", () => {
+    const content = '{"message": "Hello {world}", "type": "test"}';
+    const result = extractFirstJsonObject(content);
+
+    expect(result).toBe('{"message": "Hello {world}", "type": "test"}');
+    const parsed = JSON.parse(result!);
+    expect(parsed.message).toBe("Hello {world}");
+  });
+
+  test("handles escaped quotes inside strings", () => {
+    const content = '{"message": "Say \\"hello\\"", "type": "test"}';
+    const result = extractFirstJsonObject(content);
+
+    expect(result).toBe('{"message": "Say \\"hello\\"", "type": "test"}');
+    const parsed = JSON.parse(result!);
+    expect(parsed.message).toBe('Say "hello"');
+  });
+
+  test("handles multiple JSON objects - returns first only", () => {
+    const content = 'First: {"a": 1} Second: {"b": 2}';
+    const result = extractFirstJsonObject(content);
+
+    expect(result).toBe('{"a": 1}');
+  });
+
+  test("returns null when no JSON object found", () => {
+    const content = "No JSON here, just plain text";
+    const result = extractFirstJsonObject(content);
+
+    expect(result).toBeNull();
+  });
+
+  test("returns null for unclosed JSON", () => {
+    const content = 'Incomplete: {"type": "test"';
+    const result = extractFirstJsonObject(content);
+
+    expect(result).toBeNull();
+  });
+
+  test("handles complex nested structures", () => {
+    const content = `
+    Result: {
+      "type": "execute",
+      "filesCreated": ["a.ts", "b.ts"],
+      "filesModified": [],
+      "commandsRun": [
+        {"command": "bun test", "success": true, "output": "passed"}
+      ],
+      "summary": "Created files"
+    }
+    `;
+    const result = extractFirstJsonObject(content);
+
+    expect(result).not.toBeNull();
+    const parsed = JSON.parse(result!);
+    expect(parsed.type).toBe("execute");
+    expect(parsed.filesCreated).toEqual(["a.ts", "b.ts"]);
+    expect(parsed.commandsRun[0].success).toBe(true);
+  });
+});
+
+describe("Message Pruning", () => {
+  // Test the pruning logic
+  function pruneMessages(
+    messages: { role: string; content: string }[],
+    maxMessages: number
+  ): void {
+    if (messages.length <= maxMessages) return;
+
+    const systemPrompt = messages[0];
+    const userPrompt = messages[1];
+    const keepCount = maxMessages - 2;
+    const recentMessages = messages.slice(-keepCount);
+
+    messages.length = 0;
+    messages.push(systemPrompt, userPrompt, ...recentMessages);
+  }
+
+  test("does not prune when under limit", () => {
+    const messages = [
+      { role: "system", content: "sys" },
+      { role: "user", content: "user" },
+      { role: "assistant", content: "response" },
+    ];
+
+    pruneMessages(messages, 50);
+
+    expect(messages).toHaveLength(3);
+  });
+
+  test("prunes to max keeping system and user prompts", () => {
+    const messages = [
+      { role: "system", content: "sys" },
+      { role: "user", content: "user" },
+      { role: "assistant", content: "old1" },
+      { role: "tool", content: "old2" },
+      { role: "assistant", content: "old3" },
+      { role: "tool", content: "old4" },
+      { role: "assistant", content: "recent1" },
+      { role: "tool", content: "recent2" },
+    ];
+
+    pruneMessages(messages, 6);
+
+    expect(messages).toHaveLength(6);
+    expect(messages[0].content).toBe("sys");
+    expect(messages[1].content).toBe("user");
+    expect(messages[2].content).toBe("old3");
+    expect(messages[5].content).toBe("recent2");
+  });
+});

--- a/test/agents/types.test.ts
+++ b/test/agents/types.test.ts
@@ -18,13 +18,32 @@ import {
 import { tools } from "../../src/llm/prompts.ts";
 
 describe("Agent Types", () => {
-  test("generateTaskId creates unique 5-char IDs", () => {
+  test("generateTaskId creates unique UUIDs", () => {
     const id1 = generateTaskId();
     const id2 = generateTaskId();
 
-    expect(id1).toHaveLength(5);
-    expect(id2).toHaveLength(5);
+    // UUIDs are 36 characters in format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    expect(id1).toHaveLength(36);
+    expect(id2).toHaveLength(36);
+    expect(id1).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+    expect(id2).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
     expect(id1).not.toBe(id2);
+  });
+
+  test("generateTaskId produces unique IDs in batch", () => {
+    const ids = new Set<string>();
+    const count = 10000;
+
+    for (let i = 0; i < count; i++) {
+      ids.add(generateTaskId());
+    }
+
+    // All IDs should be unique
+    expect(ids.size).toBe(count);
   });
 
   test("type guards correctly identify result types", () => {

--- a/test/agents/types.test.ts
+++ b/test/agents/types.test.ts
@@ -1,0 +1,147 @@
+import { test, expect, describe } from "bun:test";
+import {
+  generateTaskId,
+  isExploreResult,
+  isPlanResult,
+  isExecuteResult,
+  isVerifyResult,
+  type AgentResult,
+  type ExploreResult,
+  type PlanResult,
+} from "../../src/agents/types.ts";
+import {
+  getAgentConfig,
+  filterToolsForAgent,
+  isValidAgentType,
+  getAgentTypes,
+} from "../../src/agents/index.ts";
+import { tools } from "../../src/llm/prompts.ts";
+
+describe("Agent Types", () => {
+  test("generateTaskId creates unique 5-char IDs", () => {
+    const id1 = generateTaskId();
+    const id2 = generateTaskId();
+
+    expect(id1).toHaveLength(5);
+    expect(id2).toHaveLength(5);
+    expect(id1).not.toBe(id2);
+  });
+
+  test("type guards correctly identify result types", () => {
+    const exploreResult: ExploreResult = {
+      type: "explore",
+      files: [],
+      directories: [],
+      patterns: [],
+      summary: "test",
+    };
+
+    const planResult: PlanResult = {
+      type: "plan",
+      steps: [],
+      dependencies: [],
+      considerations: [],
+      summary: "test",
+    };
+
+    expect(isExploreResult(exploreResult)).toBe(true);
+    expect(isPlanResult(exploreResult)).toBe(false);
+    expect(isPlanResult(planResult)).toBe(true);
+    expect(isExploreResult(planResult)).toBe(false);
+  });
+});
+
+describe("Agent Registry", () => {
+  test("getAgentTypes returns all 7 agent types", () => {
+    const types = getAgentTypes();
+    expect(types).toHaveLength(7);
+    expect(types).toContain("explore");
+    expect(types).toContain("research");
+    expect(types).toContain("plan");
+    expect(types).toContain("execute");
+    expect(types).toContain("refactor");
+    expect(types).toContain("assess");
+    expect(types).toContain("verify");
+  });
+
+  test("isValidAgentType validates correctly", () => {
+    expect(isValidAgentType("explore")).toBe(true);
+    expect(isValidAgentType("plan")).toBe(true);
+    expect(isValidAgentType("invalid")).toBe(false);
+    expect(isValidAgentType("")).toBe(false);
+  });
+
+  test("getAgentConfig returns correct config for each type", () => {
+    const exploreConfig = getAgentConfig("explore");
+    expect(exploreConfig.type).toBe("explore");
+    expect(exploreConfig.maxIterations).toBe(3);
+    expect(exploreConfig.allowedTools).toContain("glob");
+    expect(exploreConfig.allowedTools).toContain("grep");
+    expect(exploreConfig.allowedTools).toContain("read_file");
+    expect(exploreConfig.allowedTools).not.toContain("bash");
+
+    const executeConfig = getAgentConfig("execute");
+    expect(executeConfig.type).toBe("execute");
+    expect(executeConfig.maxIterations).toBe(5);
+    expect(executeConfig.allowedTools).toContain("bash");
+    expect(executeConfig.allowedTools).toContain("write_file");
+  });
+
+  test("filterToolsForAgent restricts tools correctly", () => {
+    const exploreTools = filterToolsForAgent(tools, "explore");
+    const toolNames = exploreTools.map((t) => t.function.name);
+
+    expect(toolNames).toContain("glob");
+    expect(toolNames).toContain("grep");
+    expect(toolNames).toContain("read_file");
+    expect(toolNames).not.toContain("bash");
+    expect(toolNames).not.toContain("write_file");
+    expect(toolNames).not.toContain("spawn_agent");
+  });
+
+  test("execute agent has access to all file tools", () => {
+    const executeTools = filterToolsForAgent(tools, "execute");
+    const toolNames = executeTools.map((t) => t.function.name);
+
+    expect(toolNames).toContain("read_file");
+    expect(toolNames).toContain("write_file");
+    expect(toolNames).toContain("edit_file");
+    expect(toolNames).toContain("bash");
+  });
+
+  test("research agent has access to web tools", () => {
+    const researchTools = filterToolsForAgent(tools, "research");
+    const toolNames = researchTools.map((t) => t.function.name);
+
+    expect(toolNames).toContain("web_search");
+    expect(toolNames).toContain("web_fetch");
+    expect(toolNames).toContain("read_file");
+  });
+});
+
+describe("Tool Isolation", () => {
+  test("no sub-agent can access spawn_agent (prevents nesting)", () => {
+    const agentTypes = getAgentTypes();
+
+    for (const agentType of agentTypes) {
+      const agentTools = filterToolsForAgent(tools, agentType);
+      const toolNames = agentTools.map((t) => t.function.name);
+      expect(toolNames).not.toContain("spawn_agent");
+    }
+  });
+
+  test("iteration limits are set appropriately", () => {
+    // Fast agents: 3 iterations
+    expect(getAgentConfig("explore").maxIterations).toBe(3);
+    expect(getAgentConfig("assess").maxIterations).toBe(3);
+
+    // Medium agents: 4 iterations
+    expect(getAgentConfig("research").maxIterations).toBe(4);
+    expect(getAgentConfig("refactor").maxIterations).toBe(4);
+    expect(getAgentConfig("verify").maxIterations).toBe(4);
+
+    // Complex agents: 5 iterations
+    expect(getAgentConfig("plan").maxIterations).toBe(5);
+    expect(getAgentConfig("execute").maxIterations).toBe(5);
+  });
+});

--- a/test/tools/web.test.ts
+++ b/test/tools/web.test.ts
@@ -1,0 +1,69 @@
+import { test, expect, describe } from "bun:test";
+
+// Test the SSRF protection logic
+// We can't directly import the private isBlockedHost function, but we can test webFetch behavior
+
+describe("SSRF Protection", () => {
+  // Since isBlockedHost is not exported, we test the webFetch function directly
+  // These tests verify that blocked hosts are rejected
+
+  test("blocks localhost", async () => {
+    const { webFetch } = await import("../../src/tools/web.ts");
+
+    await expect(webFetch("http://localhost/test")).rejects.toThrow(
+      /Blocked.*localhost/i
+    );
+  });
+
+  test("blocks 127.0.0.1", async () => {
+    const { webFetch } = await import("../../src/tools/web.ts");
+
+    await expect(webFetch("http://127.0.0.1/test")).rejects.toThrow(
+      /Blocked.*127\.0\.0\.1/i
+    );
+  });
+
+  test("blocks private IP ranges (10.x.x.x)", async () => {
+    const { webFetch } = await import("../../src/tools/web.ts");
+
+    await expect(webFetch("http://10.0.0.1/test")).rejects.toThrow(/Blocked/i);
+  });
+
+  test("blocks private IP ranges (192.168.x.x)", async () => {
+    const { webFetch } = await import("../../src/tools/web.ts");
+
+    await expect(webFetch("http://192.168.1.1/test")).rejects.toThrow(
+      /Blocked/i
+    );
+  });
+
+  test("blocks private IP ranges (172.16-31.x.x)", async () => {
+    const { webFetch } = await import("../../src/tools/web.ts");
+
+    await expect(webFetch("http://172.16.0.1/test")).rejects.toThrow(/Blocked/i);
+    await expect(webFetch("http://172.31.255.255/test")).rejects.toThrow(
+      /Blocked/i
+    );
+  });
+
+  test("blocks AWS metadata endpoint", async () => {
+    const { webFetch } = await import("../../src/tools/web.ts");
+
+    await expect(webFetch("http://169.254.169.254/latest/meta-data")).rejects.toThrow(
+      /Blocked/i
+    );
+  });
+
+  test("blocks IPv6 loopback", async () => {
+    const { webFetch } = await import("../../src/tools/web.ts");
+
+    await expect(webFetch("http://[::1]/test")).rejects.toThrow(/Blocked/i);
+  });
+
+  test("rejects invalid URLs", async () => {
+    const { webFetch } = await import("../../src/tools/web.ts");
+
+    await expect(webFetch("not-a-url")).rejects.toThrow(/Invalid URL/i);
+    await expect(webFetch("ftp://example.com")).rejects.toThrow(/Invalid URL/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--cloud` CLI flag to switch between local (`nemotron-3-nano:30b`) and cloud-routed (`nemotron-3-nano:30b-cloud`) model variants via Ollama proxy
- Add sub-agent orchestration system with 7 specialized agent types (explore, research, plan, execute, refactor, assess, verify)
- Add parallel agent executor with terminal UI renderer
- Add web search (DuckDuckGo) and web fetch tools
- Add `spawn_agent` tool for orchestrator delegation
- Bump version to 0.2.0

## Note
This needs significant review from the ground up.

## Test plan
- [ ] Verify `--cloud` flag sets model to `nemotron-3-nano:30b-cloud`
- [ ] Verify default (no flag) uses `nemotron-3-nano:30b`
- [ ] Verify `--help` shows `--cloud` option
- [ ] Verify welcome output displays active model and mode
- [ ] Test sub-agent spawning and parallel execution
- [ ] Run `bun test` for agent type tests